### PR TITLE
feat: BaseTimeEntity 추가

### DIFF
--- a/src/main/java/com/goormy/hackathon/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/goormy/hackathon/common/entity/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.goormy.hackathon.entity;
+package com.goormy.hackathon.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/goormy/hackathon/config/JpaAuditingConfig.java
+++ b/src/main/java/com/goormy/hackathon/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.goormy.hackathon.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/goormy/hackathon/entity/BaseTimeEntity.java
+++ b/src/main/java/com/goormy/hackathon/entity/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.goormy.hackathon.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/goormy/hackathon/entity/Follow.java
+++ b/src/main/java/com/goormy/hackathon/entity/Follow.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
-public class Follow {
+public class Follow extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/goormy/hackathon/entity/Follow.java
+++ b/src/main/java/com/goormy/hackathon/entity/Follow.java
@@ -1,5 +1,6 @@
 package com.goormy.hackathon.entity;
 
+import com.goormy.hackathon.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/goormy/hackathon/entity/Like.java
+++ b/src/main/java/com/goormy/hackathon/entity/Like.java
@@ -1,5 +1,6 @@
 package com.goormy.hackathon.entity;
 
+import com.goormy.hackathon.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/goormy/hackathon/entity/Like.java
+++ b/src/main/java/com/goormy/hackathon/entity/Like.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Table(name = "likes")
-public class Like {
+public class Like extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/goormy/hackathon/entity/Post.java
+++ b/src/main/java/com/goormy/hackathon/entity/Post.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @Getter
-public class Post {
+public class Post extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")

--- a/src/main/java/com/goormy/hackathon/entity/Post.java
+++ b/src/main/java/com/goormy/hackathon/entity/Post.java
@@ -1,5 +1,6 @@
 package com.goormy.hackathon.entity;
 
+import com.goormy.hackathon.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/goormy/hackathon/entity/User.java
+++ b/src/main/java/com/goormy/hackathon/entity/User.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @Table(name="users")
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")

--- a/src/main/java/com/goormy/hackathon/entity/User.java
+++ b/src/main/java/com/goormy/hackathon/entity/User.java
@@ -1,5 +1,6 @@
 package com.goormy.hackathon.entity;
 
+import com.goormy.hackathon.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;


### PR DESCRIPTION
# Overview
- Resolve: #10 

# 변경 유형
* [x] 기능 추가 
* [ ] 버그 수정
* [ ] 성능 개선
* [ ] TC 추가
* [ ] 기타 설정(환경 설정, CI/CD, 문서...)

# 수정 내용
다음과 같은 정보를 추가합니다.
- 사용자가 팔로우한 시간
- 사용자가 좋아요 누른 시간
- Post를 생성한 시간
- 사용자를 생성한 시간


개인적인 경험으로 생성 시간과 수정 시간을 함께 BaseTimeEntity로 묶는 경우가 많았습니다.
그런데 지난 회의 때 논의한 바로는 해커톤 기간 동안 수정 관련 API가 존재하지 않기 때문에 수정 시간을 기록할 필요가 없습니다.
따라서 BaseTimeEntity는 생성 시간만 포함하였습니다.